### PR TITLE
PLAT-1038: Fixed issue with NerdClient to allow it to work again

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,7 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2
 commit = True
 tag = True
 tag_name = {new_version}
 
 [bumpversion:file:setup.py]
-

--- a/nerd/nerd_client.py
+++ b/nerd/nerd_client.py
@@ -21,7 +21,7 @@ logger.addHandler(stream)
 
 
 class NerdClient(ApiClient):
-    api_base = "http://nerd.huma-num.fr/nerd/service/"
+    api_base = "https://nerd.huma-num.fr/nerd/service/"
     max_text_length = 500  # Approximation.
     sentences_per_group = 10  # Number of sentences per group
 
@@ -217,7 +217,6 @@ class NerdClient(ApiClient):
         body = {
             "termVector": terms,
             "entities": [],
-            "onlyNER": "false",
             "customisation": "generic"
         }
 
@@ -257,8 +256,8 @@ class NerdClient(ApiClient):
 
         body = {
             "text": text,
+            "nbest": 'false',
             "entities": [],
-            "onlyNER": "false",
             "customisation": "generic"
         }
 
@@ -291,7 +290,6 @@ class NerdClient(ApiClient):
         body = {
             "shortText": query,
             "entities": [],
-            "onlyNER": "false",
             "customisation": "generic"
         }
 

--- a/nerd/nerd_client.py
+++ b/nerd/nerd_client.py
@@ -256,7 +256,6 @@ class NerdClient(ApiClient):
 
         body = {
             "text": text,
-            "nbest": 'false',
             "entities": [],
             "customisation": "generic"
         }

--- a/nerd/tests/test_nerd.py
+++ b/nerd/tests/test_nerd.py
@@ -9,48 +9,52 @@ class NerdTest(unittest.TestCase):
         self.target = NerdClient()
 
     def testDisambiguateText_longText(self):
-        result = self.target.disambiguate_text("We introduce in this paper D-SPACES, an implementation of constraint "
-                                               "systems with space and extrusion operators. Constraint systems are "
-                                               "algebraic models that allow for a semantic language-like "
-                                               "representation of information in systems where the concept of space is "
-                                               "a primary structural feature. We give this information mainly an "
-                                               "epistemic interpretation and consider various agents as entities "
-                                               "acting upon it. D-SPACES is coded as a c++11 library providing "
-                                               "implementations for constraint systems, space functions and extrusion "
-                                               "functions. The interfaces to access each implementation are minimal "
-                                               "and thoroughly documented. D-SPACES also provides property-checking "
-                                               "methods as well as an implementation of a specific type of constraint "
-                                               "systems (a boolean algebra). This last implementation serves as an "
-                                               "entry point for quick access and proof of concept when using these "
-                                               "models. Furthermore, we offer an illustrative example in the form of a "
-                                               "small social network where users post their beliefs and utter their "
-                                               "opinions ")
-        assert result is not None or ""
-        assert result[1] is 200
-        # assert len(result[0]['sentence']) is 2
-        assert result[0]['language']['lang'] == "en"
+        result = self.target.disambiguate_text(
+            "We introduce in this paper D-SPACES, an implementation of constraint "
+            "systems with space and extrusion operators. Constraint systems are "
+            "algebraic models that allow for a semantic language-like "
+            "representation of information in systems where the concept of space is "
+            "a primary structural feature. We give this information mainly an "
+            "epistemic interpretation and consider various agents as entities "
+            "acting upon it. D-SPACES is coded as a c++11 library providing "
+            "implementations for constraint systems, space functions and extrusion "
+            "functions. The interfaces to access each implementation are minimal "
+            "and thoroughly documented. D-SPACES also provides property-checking "
+            "methods as well as an implementation of a specific type of constraint "
+            "systems (a boolean algebra). This last implementation serves as an "
+            "entry point for quick access and proof of concept when using these "
+            "models. Furthermore, we offer an illustrative example in the form of a "
+            "small social network where users post their beliefs and utter their "
+            "opinions "
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
+        self.assertEqual(len(result[0]['entities']), 22)
+        self.assertEqual(len(result[0]['sentences']), 8)
+        self.assertEqual(result[0]['language']['lang'], "en")
 
     def testDisambiguateText_shortText(self):
         result = self.target.disambiguate_text("This text is ")
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
+        self.assertEqual(len(result[0]['entities']), 0)
 
     def testProcessQuery_prepared_simpleText(self):
         query = {'text': "This is a simple text"}
         result = self.target._process_query(query, True)
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     def testProcessQuery_shortText(self):
         query = {'text': "This is a simple"}
         result = self.target._process_query(query)
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     def testDisambiguateQuery(self):
         result = self.target.disambiguate_query("python acronym")
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     # def testDisambiguatePdf(self):
     #     result = self.target.disambiguate_pdf("/Users/lfoppiano/Downloads/entity-fishing-dariah.pdf")
@@ -108,22 +112,28 @@ class NerdTest(unittest.TestCase):
                  }
 
         result = self.target._process_query(query)
-        assert result is not None
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     def testGetConceptWikidata(self):
         result = self.target.get_concept('Q142')
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     def testGetConceptWikipedia(self):
         result = self.target.get_concept('195', 'fr')
-        assert result is not None
-        assert result[1] is 200
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
     def testTermDisambiguation(self):
-        result = self.target.disambiguate_terms([{'term': 'car', 'score': 0.8}, {'term': 'cat', 'score': '0.3'}])
-        assert result is not None
-        assert result[1] is 200
+        result = self.target.disambiguate_terms(
+            [
+                {'term': 'car', 'score': 0.8},
+                {'term': 'cat', 'score': '0.3'}
+            ]
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[1], 200)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def my_test_suite():
 
 setup(
     name='entity-fishing-client',
-    version='0.7.1',
+    version='0.7.2',
     description='A minimal client for entity-fishing service.',
     long_description=long_description,
     url='https://github.com/Hirmeos/entity-fishing-client-python',


### PR DESCRIPTION
Removed `"onlyNER": "false",` key value from dict being passed into `NerdClient._process_query(body)` method, as was causing:

`nerd.nerd_client - ERROR - Error when processing the query`

Also have updated NerdClient.base_api to use https version of url, and fixed unit tests failing.